### PR TITLE
Automatically publish changelog to NodePit

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
-Cyface KNIME Nodes
-==================
+# Cyface KNIME Nodes
 
 [![Run Status](https://api.shippable.com/projects/5b22529108daf207007b4520/badge?branch=master)](https://app.shippable.com/github/cyface-de/knime-nodes)
 [![Coverage Badge](https://api.shippable.com/projects/5b22529108daf207007b4520/coverageBadge?branch=master)](https://app.shippable.com/github/cyface-de/knime-nodes)
@@ -15,57 +14,56 @@ Some of the Nodes are work in progress and will not work directly. Please see th
 - **Map Matching (WIP):** A node to map match a table of coordinates. This is still work in progress and does not work yet.
 - **Smooting:** A node for smoothing a data signal.
 
-Installation 
-------------
+## Installation
 
 Requirements:
- 
-* KNIME, https://www.knime.org 
 
-Steps to get Cyface KNIME Nodes inside KNIME: 
+- KNIME, <https://www.knime.org>
 
-1. Goto Help > Install new software ... menu 
-2. Press add button 
-3. Fill text fields with `http://download.nodepit.com/cyface/3.6` 
-4. Select --all sites-- in work with pulldown 
-5. Select Cyface KNIME Nodes 
-6. Install software & restart (for now an "Unsigned Content" warning can popup during the installation, you can safely ignore this) 
+Steps to get Cyface KNIME Nodes inside KNIME:
 
-Development 
------------
+1. Goto Help > Install new software ... menu
+2. Press add button
+3. Fill text fields with `http://download.nodepit.com/cyface/3.5`
+4. Select --all sites-- in work with pulldown
+5. Select Cyface KNIME Nodes
+6. Install software & restart (for now an "Unsigned Content" warning can popup during the installation, you can safely ignore this)
+
+## Development
 
 Development requirements:
- 
-* Eclipse, https://eclipse.org 
-* Maven, https://maven.apache.org 
 
-Steps to get development environment setup: 
+- Eclipse, <https://eclipse.org>
+- Maven, <https://maven.apache.org>
 
-1. Download, install and run [Eclipse Oxygen](http://www.eclipse.org/downloads/packages/eclipse-ide-java-developers/oxygenr) 
-2. Clone this Git repository 
-3. Import root project folder (pom.xml) into Eclipse using `File → Import... → Maven → Existing Maven Projects` 
-4. Open subproject `targetplatform/de.cyface.knime.targetplatform.target` in Eclipse and select `Set as Active Target Platform` 
+Steps to get development environment setup:
 
-During import the Tycho Eclipse providers have to be be installed. If this is not done automatically by Eclipse, perform the following steps: 
+1. Download, install and run [Eclipse Oxygen](http://www.eclipse.org/downloads/packages/eclipse-ide-java-developers/oxygenr)
+2. Clone this Git repository
+3. Import root project folder (pom.xml) into Eclipse using `File → Import... → Maven → Existing Maven Projects`
+4. Open subproject `targetplatform/de.cyface.knime.targetplatform.target` in Eclipse and select `Set as Active Target Platform`
 
-1. Goto Eclipse Preferences and browse to `Maven → Discovery → Open Catalog` 
-2. Install Tycho Integrations 
+During import the Tycho Eclipse providers have to be be installed. If this is not done automatically by Eclipse, perform the following steps:
 
-### Build 
+1. Goto Eclipse Preferences and browse to `Maven → Discovery → Open Catalog`
+2. Install Tycho Integrations
 
-The following command builds the entire project: 
+### Build
 
-``` 
-mvn clean package 
+The following command builds the entire project:
+
+```bash
+mvn clean package
 ```
 
-### Test 
+### Test
 
-The following command builds the entire project, creates an update site, runs unit tests and test workflows: 
+The following command builds the entire project, creates an update site, runs unit tests and test workflows:
 
-``` 
-mvn clean verify 
+```bash
+mvn clean verify
 ```
+
 **ATTENTION**: Make sure to use Java 8. Building this does not yet work with higher versions yet.
 
 ### Run the Knime node directly from Eclipse
@@ -86,7 +84,7 @@ In order to test changes made to the Cyface Binary Format Reader node you can ex
 - Navigate to `File > Export > Plug-in Development > Deployable plugins and fragments`
 - Select `de.cyface.knime` plugin and a destination directory
 
-_(Source: https://www.knime.com/developer/documentation/export)_
+_(Source: <https://www.knime.com/developer/documentation/export>)_
 
 ### Import manually exported Knime node into Knime
 
@@ -101,37 +99,31 @@ In order to test your changed, exported Cyface Binary Format Reader you can impo
 - Copy the generated (exported) JAR file into the `plugins` folder of the Knime installation
 - Restart Knime
 
-Releasing a new version
------------------------
+### Releasing a new version
 
 To release a new version of the Cyface KNIME nodes you should use the Tycho versions plugin. Just call:
 
-    mvn tycho-versions:set-version -DnewVersion=X.X.X-XXX
+```bash
+mvn tycho-versions:set-version -DnewVersion=X.X.X-XXX
+```
 
 and substitute X.X.X-XXX with your new version. The project is versioned using semantic versioning. A samll fix on version 1.0.0 thus should result in a new version 1.0.1. Extensions to the current API should result in 1.1.0 and breaking changes to the existing API should result in a new version 2.0.0. Snapshot versions on the dev branch can have the SNAPSHOT keyword attached, like for example 1.0.0-SNAPSHOT while true releases are qualifier free like 1.0.0.
 
 **ATTENTION**: Do not use the maven release plugin. This will not work, since there are some Eclipse configuration files, where you need to change the version as well. You may of course do that by hand, but that is tedious and error prone.
 
-### Release to the Nodepit repository
+Builds of the `master` branch are automatically pushed to and published on NodePit.
 
-- Push your release to Github
-- Set a tag using `git tag -a #VERSION_NAME`
-- Push the tag to Github
-- Mark the tag as a release using the Github.com UI
-- Successful release builds are then automatically pushed by our CI to Nodepit
+## Licensing
 
-Licensing
----------
+Copyright 2018, 2019, 2020 Cyface GmbH
 
-Copyright 2018, 2019 Cyface GmbH
- 
 This file is part of the Cyface KNIME Nodes.
 
 The Cyface KNIME Nodes is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
 the Free Software Foundation, either version 3 of the License, or
 (at your option) any later version.
-  
+
 The Cyface KNIME Nodes is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the

--- a/shippable.yml
+++ b/shippable.yml
@@ -22,6 +22,10 @@ language: java
 jdk:
   - oraclejdk8
 
+# Environment variables
+env:
+  - secure: BkbBqRptG7YLiHx0Q34lPyll6pGeeSOI5g1X6Ws9cjV4q9xJ3ItUbXggqofPo1r2KO9q5zv9IMWwU91w6fgPOx9G4Ufb4NlrkstE/+87xcSK/gRNdaruu2G8dgJZ3lK2nYzeh8oalYrgE8Rh9wOGwcdSXml3EavkW84j0PL8sOeh9gRjNwFYohSknw18f1CxnGkiIVco6QdVqbnUP6GCA8ltCk2TMakv7B2LGZkxEa3kCM7EUQxLwnuxF7qTyl6vNAFtuwaS3H1FnqcbfoJxFDcHyNxMq8sXSjeZ7A/x7CYLZHAv9PWc2/kbZ8/QGCXPKuOZ3CdOt1Rd1bC9iGwgfQ==
+
 # Let Shippable inject the SSH key for nodepit.com
 integrations:
   key:
@@ -57,7 +61,8 @@ build:
         echo -e "Host *\n\tStrictHostKeyChecking no\n\n" > ~/.ssh/config &&
         user_host=debian@nodepit.com &&
         dest_directory=/home/debian/nodepit/download/files/cyface/3.5 &&
-        ssh-agent bash -c "ssh-add /tmp/ssh/nodepit && ssh $user_host 'mkdir -p $dest_directory' && scp -rp de.cyface.knime.p2/target/repository/* $user_host:$dest_directory";
+        ssh-agent bash -c "ssh-add /tmp/ssh/nodepit && ssh $user_host 'mkdir -p $dest_directory' && scp -rp de.cyface.knime.p2/target/repository/* $user_host:$dest_directory" &&
+        ./update-product.sh https://nodepit.com/api/product/cyface $PRODUCT_EDIT_TOKEN CHANGELOG.md;
       fi;
   post_ci:
     # delete display

--- a/shippable.yml
+++ b/shippable.yml
@@ -42,6 +42,7 @@ build:
     - $HOME/.m2
   ci:
     # create display for workflow tests
+    - rm /etc/apt/sources.list.d/basho_riak.list
     - apt-get update
     - apt-get install xvfb -y
     - Xvfb :12345 & export DISPLAY=:12345

--- a/shippable.yml
+++ b/shippable.yml
@@ -63,8 +63,8 @@ build:
         label=3.5 &&
         download_directory=/home/debian/nodepit/download/files/cyface/$label &&
         download_zip=${download_directory}.zip &&
-        ssh-agent bash -c "ssh-add ~/.ssh/nodepit.pem && ssh $user_host '[ -e $download_directory ] && rm -r $download_directory; mkdir -p $download_directory' && scp -rp de.cyface.knime.p2/target/repository/* $user_host:$download_directory" &&
-        ssh-agent bash -c "ssh-add ~/.ssh/nodepit.pem && ssh $user_host '[ -e $download_zip ] && rm -r $download_zip'; scp -rp de.cyface.knime.p2/target/de.cyface.knime.p2-*.zip $user_host:$download_zip" &&
+        ssh-agent bash -c "ssh-add /tmp/ssh/nodepit && ssh $user_host '[ -e $download_directory ] && rm -r $download_directory; mkdir -p $download_directory' && scp -rp de.cyface.knime.p2/target/repository/* $user_host:$download_directory" &&
+        ssh-agent bash -c "ssh-add /tmp/ssh/nodepit && ssh $user_host '[ -e $download_zip ] && rm -r $download_zip'; scp -rp de.cyface.knime.p2/target/de.cyface.knime.p2-*.zip $user_host:$download_zip" &&
         ./update-product.sh https://nodepit.com/api/product/cyface $PRODUCT_EDIT_TOKEN CHANGELOG.md;
       fi;
   post_ci:

--- a/shippable.yml
+++ b/shippable.yml
@@ -60,8 +60,11 @@ build:
         mkdir -p ~/.ssh &&
         echo -e "Host *\n\tStrictHostKeyChecking no\n\n" > ~/.ssh/config &&
         user_host=debian@nodepit.com &&
-        dest_directory=/home/debian/nodepit/download/files/cyface/3.5 &&
-        ssh-agent bash -c "ssh-add /tmp/ssh/nodepit && ssh $user_host 'mkdir -p $dest_directory' && scp -rp de.cyface.knime.p2/target/repository/* $user_host:$dest_directory" &&
+        label=3.5 &&
+        download_directory=/home/debian/nodepit/download/files/cyface/$label &&
+        download_zip=${download_directory}.zip &&
+        ssh-agent bash -c "ssh-add ~/.ssh/nodepit.pem && ssh $user_host '[ -e $download_directory ] && rm -r $download_directory; mkdir -p $download_directory' && scp -rp de.cyface.knime.p2/target/repository/* $user_host:$download_directory" &&
+        ssh-agent bash -c "ssh-add ~/.ssh/nodepit.pem && ssh $user_host '[ -e $download_zip ] && rm -r $download_zip'; scp -rp de.cyface.knime.p2/target/de.cyface.knime.p2-*.zip $user_host:$download_zip" &&
         ./update-product.sh https://nodepit.com/api/product/cyface $PRODUCT_EDIT_TOKEN CHANGELOG.md;
       fi;
   post_ci:

--- a/shippable.yml
+++ b/shippable.yml
@@ -45,18 +45,16 @@ build:
     - rm /etc/apt/sources.list.d/basho_riak.list
     - apt-get update
     - apt-get install xvfb -y
-    # create display for workflow tests
-    - Xvfb :12345 & export DISPLAY=:12345
 
     # maven build
-    - mvn -V -B clean install
+    - xvfb-run mvn -V -B clean verify
 
      # copy test and coverage results where shippable expects them
     - cp -r de.cyface.knime.tests/target/surefire-reports/. shippable/testresults/
     - cp -r de.cyface.knime.tests/target/site/jacoco/. shippable/codecoverage/
     - cp -r de.cyface.knime.tests/target/testflow-reports/. shippable/testresults/
 
-    # only upload to nodepit.com when this is running on master branch
+    # upload update site to nodepit.com when running on master branch
     - >
       if [ "$BRANCH" == "master" ] && [ "$IS_PULL_REQUEST" == false ]; then
         mkdir -p ~/.ssh &&
@@ -69,6 +67,3 @@ build:
         ssh-agent bash -c "ssh-add /tmp/ssh/nodepit && ssh $user_host '[ -e $download_zip ] && rm -r $download_zip'; scp -rp de.cyface.knime.p2/target/de.cyface.knime.p2-*.zip $user_host:$download_zip" &&
         ./update-product.sh https://nodepit.com/api/product/cyface $PRODUCT_EDIT_TOKEN CHANGELOG.md;
       fi;
-  post_ci:
-    # delete display
-    - pkill -f "Xvfb :12345"

--- a/shippable.yml
+++ b/shippable.yml
@@ -41,10 +41,11 @@ build:
   cache_dir_list:
     - $HOME/.m2
   ci:
-    # create display for workflow tests
+    # https://github.com/Shippable/support/issues/5172
     - rm /etc/apt/sources.list.d/basho_riak.list
     - apt-get update
     - apt-get install xvfb -y
+    # create display for workflow tests
     - Xvfb :12345 & export DISPLAY=:12345
 
     # maven build

--- a/update-product.sh
+++ b/update-product.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+set -e
+
+if [ "$#" -ne 3 ]; then
+  echo "Usage: $0 <url> <edit-token> <changelog.md>" >&2; exit 1
+fi
+
+URL=$1
+TOKEN=$2
+CHANGELOG=$(<$3)
+
+# https://stackoverflow.com/a/13466143
+json_escape () {
+  printf '%s' "$1" | python -c 'import json,sys; print(json.dumps(sys.stdin.read()))'
+}
+
+ESCAPED_CHANGELOG=`json_escape "$CHANGELOG"`
+
+JSON="{\"changelog\":$ESCAPED_CHANGELOG}"
+
+# https://stackoverflow.com/a/34887246
+STATUS=`curl \
+  -X PATCH "${URL}" \
+  -H "Authorization: Bearer ${TOKEN}" \
+  -H "Content-Type: application/json" \
+  --data "@-" \
+  --fail \
+  --silent \
+  --write-out "%{http_code}\n" \
+  --output /dev/null \
+  <<<"$JSON"`
+# require HTTP status 2xx
+# (consider 3xx an error as well)
+if [ "$STATUS" -lt 200 ] || [ "$STATUS" -ge 300 ]; then
+  echo "Received unexpected HTTP status $STATUS" >&2; exit 2
+fi


### PR DESCRIPTION
This PR contains the following changes:

- Fixes failing CI/CD pipeline
- Uploads a zipped update site to NodePit
- Automatically pushes the `CHANGELOG.md` to NodePit